### PR TITLE
Fixes nix-build

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,35 +1,138 @@
-index-state: 2020-11-15T00:00:00Z
+index-state: 2021-01-10T00:00:00Z
 
 packages:
   ./
+
+package byron-spec-ledger
+  tests: False
+
+package cardano-api
+  tests: False
+
+package cardano-cli
+  tests: False
+
+package ouroboros-network
+  tests: False
+
+package ouroboros-network-framework
+  tests: False
+
+package small-steps
+  tests: False
+
+package small-steps-test
+  tests: False
 
 package cardano-metadata-submitter
   ghc-options: -Wall -fwarn-redundant-constraints
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: b364d925e0a72689ecba40dd1f4899f76170b894
+  --sha256: 0igb4gnzlwxy1h40vy5s1aysmaa04wypxn7sn67qy6din7ysmad3
+  subdir:
+    binary
+    binary/test
+    cardano-crypto-class
+    cardano-crypto-praos
+    cardano-crypto-tests
+    slotting
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: f73079303f663e028288f9f4a9e08bcca39a923e
+  --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 097890495cbb0e8b62106bcd090a5721c3f4b36f
+  --sha256: 0i3y9n0rsyarvhfqzzzjccqnjgwb9fbmbs6b7vj40afjhimf5hcj
+  subdir:
+    byron/chain/executable-spec
+    byron/crypto
+    byron/crypto/test
+    byron/ledger/executable-spec
+    byron/ledger/impl
+    byron/ledger/impl/test
+    semantics/executable-spec
+    semantics/small-steps-test
+    shelley/chain-and-ledger/dependencies/non-integer
+    shelley/chain-and-ledger/executable-spec
+    shelley/chain-and-ledger/shelley-spec-ledger-test
+    shelley-ma/impl
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f
+  --sha256: 1scffi7igv4kj93bpjf8yibcaq0sskfikmm00f7r6q031l53y50c
+  subdir:
+    cardano-api
+    cardano-cli
+    cardano-config
+    cardano-node
+    hedgehog-extras
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: ed3cea18898eeb1f0c9166885f14c543341e59a4
-  --sha256: 0dsrrqnc47d455x9z1alj4m9cclv4qy99gsdjjj5v5s23giagnmm
+  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
   subdir:
     cardano-prelude
     cardano-prelude-test
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: 980e6ca052c8dbad91336b6230c58b78ac1032f5
-  --sha256: 0vid3qi20pfadjxqmklanbh701avjbclx549cqb38dvmz5p0g0xi
+  location: https://github.com/input-output-hk/goblins
+  tag: cde90a2b27f79187ca8310b6549331e59595e7ba
+  --sha256: 17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: 563e79f28c6da5c547463391d4c58a81442e48db
+  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
   subdir:
-    binary
-    cardano-crypto-class
+    contra-tracer
+    iohk-monitoring
+    plugins/backend-aggregation
+    plugins/backend-ekg
+    plugins/backend-monitoring
+    plugins/backend-trace-forwarder
+    tracer-transformers
+    plugins/scribe-systemd
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 6cb9052bde39472a0555d19ade8a42da63d3e904
+  --sha256: 0rz4acz15wda6yfc7nls6g94gcwg2an5zibv0irkxk297n76gkmg
+  subdir:
+    io-sim
+    io-sim-classes
+    network-mux
+    ouroboros-consensus
+    ouroboros-consensus-byron
+    ouroboros-consensus-cardano
+    ouroboros-consensus-shelley
+    ouroboros-network
+    ouroboros-network-framework
+    typed-protocols
+    typed-protocols-examples
+    Win32-network
 
 constraints:
-  ip < 1.5,
-  hedgehog >= 1.0,
   bimap >= 0.4.0,
   brick >= 0.47,
-  libsystemd-journal >= 1.4.4
+  hedgehog >= 1.0,
+  ip < 1.5,
+  libsystemd-journal >= 1.4.4,
+  network >= 3.1.1.0
 
 allow-newer: katip:Win32
 

--- a/cardano-metadata-submitter.cabal
+++ b/cardano-metadata-submitter.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules: Cardano.Metadata.Types
                  , Cardano.Metadata.GoguenRegistry
   other-modules: AesonHelpers
-  build-depends: base ^>=4.12.0.0
+  build-depends: base
                , aeson
                , base16-bytestring
                , base64-bytestring
@@ -47,7 +47,7 @@ library
 
 executable cardano-metadata-submitter
   main-is:             cardano-metadata-submitter.hs
-  build-depends:       base ^>=4.12.0.0
+  build-depends:       base
                      , aeson
                      , aeson-pretty
                      , base64-bytestring

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -41,7 +41,7 @@ let
       # Add dependencies
       {
         packages.cardano-metadata-submitter = {
-          components.tests.unit.build-tools = [ ];
+          # components.tests.unit.build-tools = [ ];
 
           # How to set environment variables for builds
           #preBuild = "export NETWORK=testnet";

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -12,7 +12,7 @@
 
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc865"
+, compiler ? config.haskellNix.compiler or "ghc8102"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 }:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "93f833b3390b22287d50dda70f06be5fc419f334",
-        "sha256": "0r1zj1bw67wnis2lp7fifqw5qjr260g4hg11jvyyn1kwc0bq3cs7",
+        "rev": "505130bfdaa9ecff5f50c4c415d4cb7db7089716",
+        "sha256": "1j193vhc7gd22lsk6dd8lfkq64aj7xmas23sb3gkr1v6ihchpaj6",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/93f833b3390b22287d50dda70f06be5fc419f334.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/505130bfdaa9ecff5f50c4c415d4cb7db7089716.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/src/Cardano/Metadata/Types.hs
+++ b/src/Cardano/Metadata/Types.hs
@@ -102,8 +102,6 @@ import Data.Aeson
     ( FromJSON (..), ToJSON (..), (.:), (.=) )
 import Data.Maybe
     ( fromJust )
-import Data.Text
-    ( Text )
 import Data.Text.Read
     ( decimal )
 import Network.URI
@@ -190,8 +188,6 @@ prettyPolicy = \case
         show $ ppTimelock $ toAllegraTimelock s
     Policy _ (ScriptInEra _ (SimpleScript SimpleScriptV2 s)) ->
         show $ ppTimelock $ toAllegraTimelock s
-    Policy _ (ScriptInEra _ (PlutusScript _ _)) ->
-        panic "impossible"
 
 hashPolicy :: Policy -> ScriptHash
 hashPolicy (Policy _ (ScriptInEra _ script)) =
@@ -220,8 +216,6 @@ evaluatePolicy (Policy _ script) atSlot sigs =
             evaluateAtSlot $ toAllegraTimelock s
         ScriptInEra _ (SimpleScript SimpleScriptV2 s) ->
             evaluateAtSlot $ toAllegraTimelock s
-        ScriptInEra _ (PlutusScript _ _) ->
-            panic "impossible"
   where
     evaluateAtSlot :: Timelock StandardCrypto -> Either Text ()
     evaluateAtSlot s


### PR DESCRIPTION
* Adds new cabal.project deps based on cardano-node repo cabal deps at tag `1.25.1`
* Bump niv haskell.nix pin and related index to match cardano-node tag `1.25.1` haskell.nix pin and index
* Disables haskell.nix non-existent unit test for cardano-metadata-submitter