### PR TITLE
Unify validation and submission generation

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -17,8 +17,8 @@ import Build
     , Optimizations (Fast)
     , StackExtraTestArgs (StackExtraTestArgs)
     , TestRun (TestRun)
-    , doBuild
     , Timeout (Timeout)
+    , doBuild
     , uploadCoverageIfBors
     )
 import BuildArgs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+dev:
+	nix-shell --run "ghcid -c 'cabal repl $(target) --project-file=cabal-nix.project'"
+
+repl:
+	nix-shell --run "cabal repl $(target) --project-file=cabal-nix.project"
+
+style: ## Apply stylish-haskell on all *.hs files
+	nix-shell --pure --run 'find . -type f -name "*.hs" -not -path ".git" -not -path "*.stack-work*" -not -path "./dist*" -print0 | xargs -0 stylish-haskell -i'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ your `assetName` is empty, then the `policyId` is your subject. We'll consider t
 From there, initialize a new submission using `--init` as follows:
 
 ```console
-cardano-metadata-submitter --init 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0
+cardano-metadata-submitter entry --init 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0
 ```
 
 This creates a draft JSON file named after your subject.
@@ -49,7 +49,7 @@ Asset metadata have a set of required well-known properties. At minima, you'll t
 You can pass multiple commands at once to edit a draft submission. For example:
 
 ```console
-cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 \
+cardano-metadata-submitter entry 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 \
   --name "ギル" \
   --description "The currency in all of the Final Fantasy games." \
   --policy policy.json
@@ -67,7 +67,7 @@ cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439
 | `logo`   | a PNG image file                                                      | `--logo \| -l`   |
 
 ```console
-cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 \
+cardano-metadata-submitter entry 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 \
   --ticker "GIL" \
   --url "https://finalfantasy.fandom.com/wiki/Gil" \
   --logo "icon.png"
@@ -84,7 +84,7 @@ verification is done. It is therefore possible for a previously valid metadata t
 To attest all metadata at once, simple provide a signing key file (bech32, hexadecimal or cardano-cli's text envelope):
 
 ```console
-cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 -a policy.sk
+cardano-metadata-submitter entry 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 -a policy.sk
 ```
 
 The policy from this example is quite straightforward and simply requires all signatures from a single key. So a single attestation of that key for each metadata item is sufficient.
@@ -95,7 +95,7 @@ prefix to each long command (e.g. `-N` or `--attest-name` for `name`, `-T` or `-
 > For example, if you want to only attest for the name and the ticker, you can run the following:
 >
 > ```console
-> cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 -a policy.sk \
+> cardano-metadata-submitter entry 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 -a policy.sk \
 >     --attest-name \
 >     --attest-ticker
 > ```
@@ -107,10 +107,32 @@ considered valid. That is, it has to have sufficient attestations and must conta
 update it alter on via the same process. Always think about using `--finalize` before submitting or re-submitting as a sanity check.
 
 ```console
-cardano-metadata-submitter 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 --finalize
+cardano-metadata-submitter entry 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0 --finalize
 ```
 
 Your metadata is now ready to submit :tada:!
+
+### Validating metadata
+
+You might need to validate changes to existing metadata, or validate
+metadata obtained from elsewhere (perhaps you're running your own
+registry). By using the command:
+
+```console
+cardano-metadata-submitter validate 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0.json
+```
+
+You can validate a metadata entry. This performs some additional
+validation not performed by the entry command, for example, checking
+that the maximum file size does not exceed limit.
+
+By using the command:
+
+```console
+cardano-metadata-submitter validate 19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0.json updates/19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0.json
+```
+
+You can confirm that an update to an existing metadata entry is valid.
 
 ## How to build
 

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Config where
+
+import Prelude
+
+import Cardano.Metadata.GoguenRegistry
+    ( GoguenRegistryEntry (..), PartialGoguenRegistryEntry )
+import Cardano.Metadata.Types
+    ( Subject (..), WellKnownProperty (..), emptyAttested )
+import Cardano.Slotting.Slot
+    ( SlotNo (..) )
+import Colog
+    ( pattern D, pattern E, pattern I, Severity, pattern W )
+import Control.Applicative
+    ( empty, optional, (<|>) )
+import Data.Foldable
+    ( asum )
+import Data.List
+    ( isSuffixOf )
+import Data.Text
+    ( Text )
+import Data.Void
+    ( Void )
+import qualified Options.Applicative as OA
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.Bifunctor as Bifunctor
+import qualified Data.Text as T
+import qualified Text.Megaparsec as P
+import qualified Text.Megaparsec.Char as P
+import qualified Text.Megaparsec.Char.Lexer as P
+
+type Parser = P.Parsec Void Text
+
+data SlotNoPreference
+  = MainnetTip
+  | TestnetTip
+  | CustomSlot SlotNo
+  deriving (Eq, Show)
+
+data DraftStatus
+    = DraftStatusDraft
+    | DraftStatusFinal
+    deriving Show
+
+data EntryOperation
+    = EntryOperationInitialize
+    | EntryOperationRevise
+    deriving Show
+
+data AttestationField
+    = AttestationFieldName
+    | AttestationFieldDescription
+    | AttestationFieldLogo
+    | AttestationFieldUrl
+    | AttestationFieldTicker
+    deriving (Show, Eq, Ord)
+
+data FileInfo = FileInfo
+    { _FileInfoSubject :: Subject
+    , _FileInfoEntryOperation :: EntryOperation
+    , _FileInfoDraftStatus :: DraftStatus
+    }
+  deriving Show
+
+data EntryUpdateArguments = EntryUpdateArguments
+    { _EntryUpdateArgumentsFileInfo :: FileInfo
+    , _EntryUpdateArgumentsAttestationKeyFilename :: Maybe String
+    , _EntryUpdateArgumentsAttestationFields :: [AttestationField]
+    , _EntryUpdateArgumentsRegistryEntry :: PartialGoguenRegistryEntry
+    , _EntryUpdateLogoFilename :: Maybe String
+    , _EntryUpdatePolicyFilenameOrCBOR :: Maybe String
+    }
+    deriving Show
+
+data Arguments
+    = ArgumentsEntryUpdate EntryUpdateArguments
+    | ArgumentsValidate FilePath (Maybe FilePath) Severity
+    deriving Show
+
+argumentParser :: Maybe Subject -> OA.Parser Arguments
+argumentParser defaultSubject =
+  OA.hsubparser 
+    ( OA.command "entry" (OA.info (ArgumentsEntryUpdate <$> entryUpdateArgumentParser defaultSubject) mempty)
+   <> OA.command "validate" (OA.info (ArgumentsValidate <$> pFileA <*> pFileB <*> pLogSeverity) mempty)
+    )
+
+  where
+    pFileA :: OA.Parser FilePath
+    pFileA = OA.strArgument (OA.metavar "FILE" <> OA.help "File to validate")
+
+    pFileB :: OA.Parser (Maybe FilePath)
+    pFileB = optional (OA.strArgument (OA.metavar "FILE" <> OA.help "If present, validates this file instead of the first and also validates the difference between the first and second files."))
+
+entryUpdateArgumentParser :: Maybe Subject -> OA.Parser EntryUpdateArguments
+entryUpdateArgumentParser defaultSubject = EntryUpdateArguments
+    <$> fileInfoArgumentParser
+    <*> optional (OA.strOption (OA.long "attest-keyfile" <> OA.short 'a' <> OA.metavar "ATTESTATION_KEY_FILE"))
+    <*> attestationFieldNamesParser
+    <*> goguenRegistryEntryParser
+    <*> logoFilenameParser
+    <*> policyParser
+  where
+    attestationFieldNamesParser :: OA.Parser [AttestationField]
+    attestationFieldNamesParser = asum
+        [ OA.flag' [AttestationFieldName] $ OA.long "attest-name" <> OA.short 'N'
+        , OA.flag' [AttestationFieldDescription] $ OA.long "attest-description" <> OA.short 'D'
+        , OA.flag' [AttestationFieldLogo] $ OA.long "attest-logo" <> OA.short 'L'
+        , OA.flag' [AttestationFieldUrl] $ OA.long "attest-url" <> OA.short 'H'
+        , OA.flag' [AttestationFieldTicker] $ OA.long "attest-ticker" <> OA.short 'T'
+        , pure
+            [ AttestationFieldName
+            , AttestationFieldDescription
+            , AttestationFieldLogo
+            , AttestationFieldUrl
+            , AttestationFieldTicker
+            ]
+       ]
+
+    fileInfoArgumentParser :: OA.Parser FileInfo
+    fileInfoArgumentParser = FileInfo
+        <$> (trimSubject <$> OA.strArgument (OA.metavar "SUBJECT") <|> defaultSubjectParser)
+        <*> OA.flag EntryOperationRevise EntryOperationInitialize (OA.long "init" <> OA.short 'i')
+        <*> OA.flag DraftStatusDraft DraftStatusFinal (OA.long "finalize" <> OA.short 'f')
+
+    defaultSubjectParser =
+        maybe empty pure defaultSubject
+
+    trimSubject :: String -> Subject
+    trimSubject subj
+        | jsonSuffix `isSuffixOf` subj =
+            Subject $ T.pack $ take (length subj - length jsonSuffix) subj
+        | jsonDraftSuffix `isSuffixOf` subj =
+            Subject $ T.pack $ take (length subj - length jsonDraftSuffix) subj
+        | otherwise =
+            Subject $ T.pack subj
+
+    logoFilenameParser :: OA.Parser (Maybe String)
+    logoFilenameParser = optional $ OA.strOption (OA.long "logo" <> OA.short 'l' <> OA.metavar "LOGO.png")
+
+    policyParser :: OA.Parser (Maybe String)
+    policyParser = optional (OA.strOption (OA.long "policy" <> OA.short 'p' <> OA.metavar "POLICY"))
+
+    goguenRegistryEntryParser :: OA.Parser (PartialGoguenRegistryEntry)
+    goguenRegistryEntryParser = GoguenRegistryEntry Nothing Nothing
+        <$> optional (emptyAttested <$> wellKnownOption (OA.long "name" <> OA.short 'n' <> OA.metavar "NAME"))
+        <*> optional (emptyAttested <$> wellKnownOption (OA.long "description" <> OA.short 'd' <> OA.metavar "DESCRIPTION"))
+        <*> pure Nothing -- logo
+        <*> optional (emptyAttested <$> wellKnownOption (OA.long "url" <> OA.short 'h' <> OA.metavar "URL"))
+        <*> optional (emptyAttested <$> wellKnownOption (OA.long "ticker" <> OA.short 't' <> OA.metavar "TICKER"))
+
+pSlotNoPreference :: OA.Parser SlotNoPreference
+pSlotNoPreference = 
+  OA.option (readerFromParser pSlotPref)
+    ( OA.long "slot-no"
+    <> OA.help "Slot number to use to validate wallet metadata scripts (mainnet | testnet | <WORD64>)"
+    )
+
+pSlotPref :: Parser SlotNoPreference
+pSlotPref = asum [ MainnetTip <$ P.string "mainnet"
+                 , TestnetTip <$ P.string "testnet"
+                 , CustomSlot <$> P.decimal
+                 , pure MainnetTip
+                 ]
+
+readerFromParser :: Parser a -> OA.ReadM a
+readerFromParser p =
+  OA.eitherReader
+    (  Bifunctor.first P.errorBundlePretty
+     . P.runParser (p <* P.eof) "cmd-line-args"
+     . T.pack
+    )
+
+pLogSeverity :: OA.Parser Colog.Severity
+pLogSeverity = pDebug <|> pInfo <|> pWarning <|> pError <|> pure I
+  where
+    pDebug =
+      OA.flag' D
+        (  OA.long "debug"
+        <> OA.help "Print debug, info, warning, and error messages"
+        )
+    pInfo =
+      OA.flag' I
+        (  OA.long "info"
+        <> OA.help "Print info, warning, and error messages"
+        )
+    pWarning =
+      OA.flag' W
+        (  OA.long "warning"
+        <> OA.help "Print warning, and error messages"
+        )
+    pError =
+      OA.flag' E
+        (  OA.long "error"
+        <> OA.help "Print error messages only"
+        )
+
+canonicalFilename :: FileInfo -> String
+canonicalFilename = (<> jsonSuffix) . T.unpack . unSubject . _FileInfoSubject
+
+jsonSuffix, draftSuffix, jsonDraftSuffix :: String
+jsonSuffix = ".json"
+draftSuffix = ".draft"
+jsonDraftSuffix = jsonSuffix <> draftSuffix
+
+draftFilename :: FileInfo -> String
+draftFilename fi = canonicalFilename fi <> draftSuffix
+
+wellKnownOption
+    :: forall p. WellKnownProperty p
+    => OA.Mod OA.OptionFields p
+    -> OA.Parser p
+wellKnownOption =
+    OA.option wellKnownReader
+  where
+    wellKnownReader :: OA.ReadM p
+    wellKnownReader = OA.eitherReader $
+        Aeson.parseEither parseWellKnown . Aeson.toJSON

--- a/cabal-nix.project
+++ b/cabal-nix.project
@@ -1,0 +1,4 @@
+packages:
+  ./
+tests: True
+benchmarks: True

--- a/cabal.project
+++ b/cabal.project
@@ -24,14 +24,25 @@ package small-steps
 package small-steps-test
   tests: False
 
+package metadata-lib
+  tests: False
+
 package cardano-metadata-submitter
   ghc-options: -Wall -fwarn-redundant-constraints
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/metadata-server
+  tag: aebd96c623aaf32426e9b7189d60728fd3d6b768
+  --sha256: 1s01f6lni4flya3hqn4b0b91gr0arqc5hkb09dk4c5hn7a54g49i
+  subdir:
+    metadata-lib
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: b364d925e0a72689ecba40dd1f4899f76170b894
-  --sha256: 0igb4gnzlwxy1h40vy5s1aysmaa04wypxn7sn67qy6din7ysmad3
+  tag: 4251c0bb6e4f443f00231d28f5f70d42876da055
+  --sha256: 02a61ymvx054pcdcgvg5qj9kpybiajg993nr22iqiya196jmgciv
   subdir:
     binary
     binary/test
@@ -49,8 +60,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 097890495cbb0e8b62106bcd090a5721c3f4b36f
-  --sha256: 0i3y9n0rsyarvhfqzzzjccqnjgwb9fbmbs6b7vj40afjhimf5hcj
+  tag: 99e2f2e32ebfca3291fa523ddcae14c8cbb48fa0
+  --sha256: 0fy8y7cp10ls8p3zs2fqzqpd41vri6z0imhyif5wa9bi2rp57i3z
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -66,22 +77,22 @@ source-repository-package
     shelley-ma/impl
 
 source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-node
-  tag: 9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f
-  --sha256: 1scffi7igv4kj93bpjf8yibcaq0sskfikmm00f7r6q031l53y50c
-  subdir:
-    cardano-api
-    cardano-cli
-    cardano-config
-    cardano-node
-    hedgehog-extras
+    type: git
+    location: https://github.com/input-output-hk/cardano-node
+    tag: e15515b785f7caae0ae5d997b26d9c4518062c71
+    --sha256: 14w39l4jgxhb68xzv889bibj8q44aknqnsdrz1kbwx2ca3yzbkpw
+    subdir: cardano-api
+            cardano-api/test
+            cardano-cli
+            cardano-config
+            cardano-node
+            hedgehog-extras
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
-  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
+  tag: 116087dbcebb88aafdc7d3d0577477ba36129b41
+  --sha256: 0kxk5vcywsl19qc65y8mkc0npv5qz9fm23avs247xnb0zq17wcrd
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -95,8 +106,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 563e79f28c6da5c547463391d4c58a81442e48db
-  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
+  tag: 60b13d80afa266f02f363672950e896ed735e807
+  --sha256: 0gci6r4c6ldrgracbr4fni4hbrl62lmm5p70cafkwk21a0kqs8cz
   subdir:
     contra-tracer
     iohk-monitoring
@@ -104,13 +115,14 @@ source-repository-package
     plugins/backend-ekg
     plugins/backend-monitoring
     plugins/backend-trace-forwarder
+    plugins/scribe-systemd
     tracer-transformers
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6cb9052bde39472a0555d19ade8a42da63d3e904
-  --sha256: 0rz4acz15wda6yfc7nls6g94gcwg2an5zibv0irkxk297n76gkmg
+  tag: 96cf17bcc6ea4ef455a19430313ce17d476d62b5
+  --sha256: 00xp605lb8qp1jhp43mg7818x8yzn2rnsd18qcy5721yj4q675nz
   subdir:
     io-sim
     io-sim-classes
@@ -126,13 +138,19 @@ source-repository-package
     Win32-network
 
 constraints:
-  bimap >= 0.4.0,
-  brick >= 0.47,
-  hedgehog >= 1.0,
-  ip < 1.5,
-  network >= 3.1.1.0
+    bimap >= 0.4.0
+  , brick >= 0.47
+  , hedgehog >= 1.0
+  , ip < 1.5
+  , libsystemd-journal >= 1.4.4
+  , network >= 3.1.1.0
+  , systemd >= 2.3.0
+    -- systemd-2.3.0 requires at least network 3.1.1.0 but it doesn't declare
+    -- that dependency
 
-allow-newer: katip:Win32
+allow-newer:
+  katip:Win32
+  github:base16-bytestring
 
 package comonad
   flags: -test-doctests

--- a/cardano-metadata-submitter.cabal
+++ b/cardano-metadata-submitter.cabal
@@ -18,6 +18,7 @@ flag development
 library
   exposed-modules: Cardano.Metadata.Types
                  , Cardano.Metadata.GoguenRegistry
+                 , Cardano.Metadata.Validation.Wallet
   other-modules: AesonHelpers
   build-depends: base
                , aeson
@@ -39,6 +40,12 @@ library
                , containers
                , cborg
                , time
+               , co-log
+               , megaparsec
+               , mtl
+               , filepath
+               , metadata-lib
+               , validation
   hs-source-dirs: src
   default-language: Haskell2010
   default-extensions: NoImplicitPrelude
@@ -55,8 +62,13 @@ executable cardano-metadata-submitter
                      , bytestring
                      , cardano-prelude
                      , cardano-metadata-submitter
+                     , safe-exceptions
+                     , co-log
+                     , validation
                      , directory
                      , optparse-applicative
+                     , megaparsec
+                     , metadata-lib
                      , text
                      , cardano-api
                      , cardano-cli
@@ -68,3 +80,4 @@ executable cardano-metadata-submitter
                       OverloadedStrings
   if (!flag(development))
     ghc-options: -Werror -Wall
+  other-modules:       Config

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "505130bfdaa9ecff5f50c4c415d4cb7db7089716",
-        "sha256": "1j193vhc7gd22lsk6dd8lfkq64aj7xmas23sb3gkr1v6ihchpaj6",
+        "rev": "9f774325bc43c405802232bf29a8ce1c2f48bb75",
+        "sha256": "0pkw3ayzfwqf0cnv8cf8sbmhlfqadz2804iv43i9z37ryajcvvh0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/505130bfdaa9ecff5f50c4c415d4cb7db7089716.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/9f774325bc43c405802232bf29a8ce1c2f48bb75.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/release.nix
+++ b/release.nix
@@ -46,11 +46,10 @@ let
   testsSupportedSystems = [ "x86_64-linux" ];
   collectTests = ds: filter (d: elem d.system testsSupportedSystems) (collect isDerivation ds);
 
-  inherit (systems.examples) mingwW64 musl64;
+  inherit (systems.examples) musl64;
 
   jobs = {
     native = mapTestOn (packagePlatforms project);
-    "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross project);
   } // (mkRequiredJob (
       collectTests jobs.native.checks.tests ++
       collectTests jobs.native.benchmarks ++

--- a/src/Cardano/Metadata/Validation/Wallet.hs
+++ b/src/Cardano/Metadata/Validation/Wallet.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | Wallet-specific validation rules.
+-}
+
+module Cardano.Metadata.Validation.Wallet
+  ( WalletValidationError(..)
+  , prettyPrintWalletValidationError
+  , walletValidationRules
+  , walletValidation
+  ) where
+
+import Cardano.Metadata.GoguenRegistry
+    ( PartialGoguenRegistryEntry, parseRegistryEntry, validateEntry )
+import Cardano.Metadata.Types.Common
+    ( File, fileContents )
+import Cardano.Metadata.Validation.Rules
+    ( Transform, ValidationError (ErrorCustom), defaultRules, mkTransform )
+import Cardano.Metadata.Validation.Types
+    ( Difference (Added, Changed, Removed), invalid, valid )
+import qualified Cardano.Metadata.Validation.Types as Common
+    ( Metadata )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Text
+    ( Text )
+import Data.Validation
+    ( Validation )
+import Prelude hiding
+    ( log )
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.Text as T
+
+data WalletValidationError
+  = WalletFailedToParseRegistryEntry Aeson.Value String
+  -- ^ Failed to parse a metadata entry from the file contents (json value, err)
+  | WalletFailedToValidate PartialGoguenRegistryEntry Text
+  -- ^ Failed to validate the metadata entry (json value, err)
+
+-- | Pretty print a wallet-specific validation error.
+prettyPrintWalletValidationError :: WalletValidationError -> Text
+prettyPrintWalletValidationError (WalletFailedToParseRegistryEntry val err) =
+  "Failed to parse wallet metadata entry from JSON: '" <> T.pack (show val) <> "', error was: " <> T.pack err <> "."
+prettyPrintWalletValidationError (WalletFailedToValidate val err) =
+  "Failed to validate wallet metadata entry '" <> T.pack (show val) <> "', error was: '" <> err <> "'."
+
+-- | The wallet validation rules consist of the default validation
+-- rules for metadata, as well as some wallet-specific validation (see
+-- @walletValidation@).
+walletValidationRules
+  :: Transform
+       (Difference (File Common.Metadata))
+       (Validation (NonEmpty (ValidationError WalletValidationError)))
+       ()
+walletValidationRules =
+  defaultRules
+  *> mkTransform walletValidation
+
+-- | Try to parse and validate a wallet metadata entry (see
+-- @parseRegistryEntry@ and @validateEntry@).
+walletValidation
+  :: Difference (File Common.Metadata)
+  -> Validation (NonEmpty (ValidationError WalletValidationError)) ()
+walletValidation diff = do
+  -- Find the new file we are going to validate
+  let
+    mMeta =
+      case diff of
+        Added newFile     -> Just (fileContents newFile)
+        Removed _         -> Nothing
+        Changed _ newFile -> Just (fileContents newFile)
+
+  case mMeta of
+    -- If we've removed a file, don't need to perform wallet validation
+    Nothing      -> valid
+    Just newMeta -> do
+      let json = Aeson.toJSON newMeta
+      case Aeson.parseEither parseRegistryEntry json of
+        Left e      ->
+          invalid (ErrorCustom $ WalletFailedToParseRegistryEntry json e)
+        Right entry -> do
+          case validateEntry entry of
+            Left e -> do
+              invalid (ErrorCustom $ WalletFailedToValidate entry e)
+            Right () ->
+              valid
+

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -294,7 +294,7 @@ function fixture(done) {
         const prepared = args.map(arg => arg.startsWith("-") ? arg : `"${arg}"`);
         const opts = { cwd, stdio: 'ignore'  }
         // const opts = { cwd }
-        return execSync(`cardano-metadata-submitter ${subject} ${prepared.join(" ")}`, opts);
+        return execSync(`cardano-metadata-submitter entry ${subject} ${prepared.join(" ")}`, opts);
       };
 
       getDraft = function getDraft(subject) {


### PR DESCRIPTION
- Split the cardano-metadata-submitter executable into two
  sub-programs. Users can now pass the:
  - "entry" argument (i.e. "cardano-metadata-submitter entry ...") to
    recover the original behaviour.
  - "validate" argument to validate created entries.
- Added the "metadata-server" project as a dependency. It now offers a
  "metadata-lib" library which we use here for it's validation
  component. The validation component provides us with definitions for
  the default rules applicable to all metadata, and means to create
  our own. We define our own wallet-specific validation rules and
  append them to the defaults.
- Created a new "Cardano.Metadata.Validation.Wallet" module to hold
  this new validation logic.
- Add simple Makefile to make entering a development environment
  easier on Nix, plus target to apply styling.
- Move command line parsing and program configuration into 'Config'
  module to keep some separation of responsiblity.